### PR TITLE
Require post on workflow validation field.  

### DIFF
--- a/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/config.jelly
+++ b/cps/src/main/resources/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition/config.jelly
@@ -25,6 +25,6 @@
 
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
   <f:entry title="${%Script}" field="script">
-    <f:textarea />
+    <f:textarea checkMethod="post"/>
   </f:entry>
 </j:jelly>


### PR DESCRIPTION
A sufficiently long workflow will overrun the maximum request length in most browsers, resulting in no validation taking place and a HTTP error.  Might want to also consider RequirePOST on the method in CpsFlowDefinition.
