### PR TITLE
Changed the exposure for SCMStep so I can extend it in another plugin

### DIFF
--- a/scm-step/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
+++ b/scm-step/src/main/java/org/jenkinsci/plugins/workflow/steps/scm/SCMStep.java
@@ -45,7 +45,7 @@ import org.jenkinsci.plugins.workflow.steps.StepExecution;
 /**
  * A step which uses some kind of {@link SCM}.
  */
-abstract class SCMStep extends Step {
+public abstract class SCMStep extends Step {
 
     private final boolean poll;
     private final boolean changelog;
@@ -118,7 +118,7 @@ abstract class SCMStep extends Step {
         return new StepExecutionImpl(context);
     }
 
-    protected static abstract class SCMStepDescriptor extends StepDescriptor {
+    public static abstract class SCMStepDescriptor extends StepDescriptor {
 
         @Override public Set<Class<?>> getRequiredContext() {
             Set<Class<?>> s = new HashSet<Class<?>>();


### PR DESCRIPTION
We have several different SCM front ends that use the same back end. And to make it easier to configure I would like to be able to extend the SCMStep in our plugin. But if the class SCMStep and SCMStepDescriptor did not have the public state I could not access them in my plugin. 
Could also that I'm missing some thing simple.
I can send the class name as described in the example but it would be easier if I could create my own wrappers.
