### PR TITLE
Better Exception message on 'unarchive' step

### DIFF
--- a/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/ArtifactUnarchiverStepExecution.java
+++ b/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/ArtifactUnarchiverStepExecution.java
@@ -37,6 +37,9 @@ public class ArtifactUnarchiverStepExecution extends AbstractSynchronousStepExec
 
         List<FilePath> files = new ArrayList<FilePath>();
 
+        if (step.mapping == null)
+            throw new AbortException("'mapping' has not been defined for this 'unarchive' step");
+
         for (Entry<String, String> e : step.mapping.entrySet()) {
             FilePath dst = new FilePath(ws,e.getValue());
             String src = e.getKey();


### PR DESCRIPTION
Enhance the exception message if 'mapping' is not defined on 'unarchive' step.
