### PR TITLE
Fix link to JIRA

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The snapshot Docker demo is mainly useful for verifying the effect of ongoing ch
 
 * [Changelog](CHANGES.md)
 * [Source repository](https://github.com/jenkinsci/workflow-plugin)
-* [JIRA](https://issues.jenkins-ci.org/secure/IssueNavigator.jspa?reset=true&jqlQuery=project+%3D+JENKINS+AND+resolution+%3D+Unresolved+AND+component+%3D+workflow+ORDER+BY+priority+DESC&mode=hide)
+* [JIRA](https://issues.jenkins-ci.org/browse/JENKINS/component/18820)
 * [Trello board](https://trello.com/b/u2fJQnDX/workflow) tracking active and proposed tasks.
 * [CI job](https://jenkins.ci.cloudbees.com/job/plugins/job/workflow-plugin/) with validated merge support.
   [![Build Status](https://jenkins.ci.cloudbees.com/buildStatus/icon?job=plugins/workflow-plugin)](https://jenkins.ci.cloudbees.com/job/plugins/job/workflow-plugin/)


### PR DESCRIPTION
Update JIRA link to point to workflow-plugin component overview.

The current link points to (at least being not logged-in in issues.jenkins-ci.org) to a non-existing page...
