### PR TITLE
[JENKINS-25736] Adding the pause functionality

### DIFF
--- a/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
+++ b/cps/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowExecution.java
@@ -788,6 +788,22 @@ public class CpsFlowExecution extends FlowExecution {
         }
     }
 
+    /**
+     * Pause or unpause the execution.
+     *
+     * @param v
+     *      true to pause, false to unpause.
+     */
+    public void pause(final boolean v) {
+        Futures.addCallback(programPromise, new FutureCallback<CpsThreadGroup>() {
+            @Override public void onSuccess(CpsThreadGroup g) {
+                if (v)      g.pause();
+                else        g.unpause();
+            }
+            @Override public void onFailure(Throwable _) {}
+        });
+    }
+
     @Override public String toString() {
         return "CpsFlowExecution[" + owner + "]";
     }


### PR DESCRIPTION
[JENKINS-25736](https://issues.jenkins-ci.org/browse/JENKINS-25736)

@uaarkoti told me that he talks to lots of people who wants to be able
to arbitrarily pause workflows while they are executing.

This seems like a relatively easy addition as far as the engine is
concerned, so this is a prototype of that functionality.

Given the way the things are split into plugins I'm not sure how to
properly expose this to UI --- should the pausability be a base contract
of FlowExecution, or should I define TransientActionFactory impl that
depends on both WorkflowRun and CpsFlowExecution that adds an Action
from outside?