### PR TITLE
[JENKINS-31999] Adding ecutest-plugin to COMPATIBLITY.md

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -65,7 +65,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [X] `LambdaUploadBuildStep`, `LambdaInvokeBuildStep`, `LambdaEventSourceBuildStep` (`aws-lambda`): supported as of 0.5.0
 - [X] `CucumberReportPublisher` (`cucumber-reports`): supported as of 2.1.0
 - [ ] `Powershell` (`powershell`): [JENKINS-34581](https://issues.jenkins-ci.org/browse/JENKINS-34581)
-- [X] `TestPackageBuilder` (+6 more), `ATXPublisher` (+4 more) (`ecutest`): supported as of 1.11.0
+- [X] `TestPackageBuilder` (+6 more), `ATXPublisher` (+4 more) (`ecutest`): supported as of 1.11
 
 ## Build wrappers
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -65,7 +65,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [X] `LambdaUploadBuildStep`, `LambdaInvokeBuildStep`, `LambdaEventSourceBuildStep` (`aws-lambda`): supported as of 0.5.0
 - [X] `CucumberReportPublisher` (`cucumber-reports`): supported as of 2.1.0
 - [ ] `Powershell` (`powershell`): [JENKINS-34581](https://issues.jenkins-ci.org/browse/JENKINS-34581)
-- [ ] `TestPackageBuilder` (+6 more), `ATXPublisher` (+4 more) (`ecutest`): [JENKINS-31999](https://issues.jenkins-ci.org/browse/JENKINS-31999)
+- [X] `TestPackageBuilder` (+6 more), `ATXPublisher` (+4 more) (`ecutest`): supported as of 1.11.0
 
 ## Build wrappers
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -65,6 +65,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [X] `LambdaUploadBuildStep`, `LambdaInvokeBuildStep`, `LambdaEventSourceBuildStep` (`aws-lambda`): supported as of 0.5.0
 - [X] `CucumberReportPublisher` (`cucumber-reports`): supported as of 2.1.0
 - [ ] `Powershell` (`powershell`): [JENKINS-34581](https://issues.jenkins-ci.org/browse/JENKINS-34581)
+- [ ] `TestPackageBuilder` (+6 more), `ATXPublisher` (+4 more) (`ecutest`): [JENKINS-31999](https://issues.jenkins-ci.org/browse/JENKINS-31999)
 
 ## Build wrappers
 


### PR DESCRIPTION
The plugin provides several build steps and post-build actions:
Builder: Test[Package|Project|Folder]Builder, Start[ET|TS]Builder, Stop[ET|TS]Builder
Publisher: [ATX|ETLog|JUnit|ReportGenerator|TRF]Publisher