### PR TITLE
Add `checkout scm` line to "Creating a Simple Pipeline"

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -97,6 +97,7 @@ Now, click on your Pipeline and **Configure** it to edit its script.
 
 ```groovy
 node {
+  checkout scm
   git url: 'https://github.com/jglick/simple-maven-project-with-tests.git'
   def mvnHome = tool 'M3'
   sh "${mvnHome}/bin/mvn -B verify"


### PR DESCRIPTION
This `checkout scm` line is only mentioned in more complex pipelines, but seems to be required for even simple pipelines. Took me a long time to figure out I needed to add this to my `node {...}` declarations.