### PR TITLE
[JENKINS-27302] Clover is compatible with Pipeline since 4.6.0

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -39,7 +39,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [ ] `JaCoCoPublisher` (`jacoco`): [JENKINS-27120](https://issues.jenkins-ci.org/browse/JENKINS-27120)
 - [ ] `Publisher` (`testng`): [JENKINS-27121](https://issues.jenkins-ci.org/browse/JENKINS-27121)
 - [ ] `Gradle` (`gradle`): [JENKINS-27393](https://issues.jenkins-ci.org/browse/JENKINS-27393)
-- [ ] `CloverPublisher` (`clover`): [JENKINS-27302](https://issues.jenkins-ci.org/browse/JENKINS-27302)
+- [X] `CloverPublisher` (`clover`): [JENKINS-27302](https://issues.jenkins-ci.org/browse/JENKINS-27302)
 - [ ] `MsBuildBuilder` (`msbuild`): [JENKINS-26948](https://issues.jenkins-ci.org/browse/JENKINS-26948)
 - [X] `HipChatNotifier` (`hipchat`): supported as of 1.0.0
 - [ ] `IronMQNotifier` (`ironmq-notifier`): [JENKINS-35505](https://issues.jenkins-ci.org/browse/JENKINS-35505)

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -39,7 +39,7 @@ Entries list the class name serving as the entry point to the relevant functiona
 - [ ] `JaCoCoPublisher` (`jacoco`): [JENKINS-27120](https://issues.jenkins-ci.org/browse/JENKINS-27120)
 - [ ] `Publisher` (`testng`): [JENKINS-27121](https://issues.jenkins-ci.org/browse/JENKINS-27121)
 - [ ] `Gradle` (`gradle`): [JENKINS-27393](https://issues.jenkins-ci.org/browse/JENKINS-27393)
-- [X] `CloverPublisher` (`clover`): [JENKINS-27302](https://issues.jenkins-ci.org/browse/JENKINS-27302)
+- [X] `CloverPublisher` (`clover`): supported as of 4.6.0
 - [ ] `MsBuildBuilder` (`msbuild`): [JENKINS-26948](https://issues.jenkins-ci.org/browse/JENKINS-26948)
 - [X] `HipChatNotifier` (`hipchat`): supported as of 1.0.0
 - [ ] `IronMQNotifier` (`ironmq-notifier`): [JENKINS-35505](https://issues.jenkins-ci.org/browse/JENKINS-35505)


### PR DESCRIPTION
According to [JENKINS-27302](https://issues.jenkins-ci.org/browse/JENKINS-27302)