### PR TITLE
[JENKINS-30700] Add CoberturaPublisher to compatability note

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -31,6 +31,7 @@ Newly filed issues should bear the label `pipeline` for ease of tracking.
 - [X] `CopyArtifact` (`copyartifact`): [JENKINS-24887](https://issues.jenkins-ci.org/browse/JENKINS-24887) in 1.34
 - [ ] `DeployPublisher` (`deployer-framework`): [JENKINS-25976](https://issues.jenkins-ci.org/browse/JENKINS-25976)
 - [X] Analysis publishers (e.g., `FindBugsPublisher`): supported as of `analysis-core` 1.73 and downstream plugins (e.g., `findbugs` 4.62)
+- [ ] `CoberturaPublisher` (`cobertura`): [PR 55](https://github.com/jenkinsci/cobertura-plugin/pull/55)
 - [ ] `Ant` (`ant`): [JENKINS-26056](https://issues.jenkins-ci.org/browse/JENKINS-26056)
 - [ ] `Maven` (home TBD): [JENKINS-26057](https://issues.jenkins-ci.org/browse/JENKINS-26057)
 - [ ] `XShellBuilder` (`xshell`): [JENKINS-26169](https://issues.jenkins-ci.org/browse/JENKINS-26169)


### PR DESCRIPTION
PR 55 (https://github.com/jenkinsci/cobertura-plugin/pull/55)

Signed-off-by: Alan Zaffetti <alan.zaffetti@ibm.com>