### PR TITLE
Build parameters not groovy variables anymore

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -259,8 +259,6 @@ See  Help in the **Snippet Generator** for the `withEnv` step for more details o
 
 If you have configured your pipeline to accept parameters when it is built — **Build with Parameters** — they are accessible as Groovy variables inside `params`. They are also accessible as environment variables.
 
-Example:
-
 **Example**: Using `isFoo` parameter defined as a boolean parameter (checkbox in the UI):
 
 ```groovy

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -257,12 +257,16 @@ See  Help in the **Snippet Generator** for the `withEnv` step for more details o
 
 ## Build Parameters
 
-If you have configured your pipeline to accept parameters when it is built — **Build with Parameters** — they are accessible as Groovy variables inside `params`. Example:
+If you have configured your pipeline to accept parameters when it is built — **Build with Parameters** — they are accessible as Groovy variables inside `params`. They are also accessible as environment variables.
+
+Example:
+
+**Example**: Using `isFoo` parameter defined as a boolean parameter (checkbox in the UI):
 
 ```groovy
 node {
   sh "isFoo is ${params.isFoo}"
-  sh "isFoo is " + params.isFoo
+  sh 'isFoo is ' + params.isFoo
   if (params.isFoo) {
     // do something
   }

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -257,7 +257,16 @@ See  Help in the **Snippet Generator** for the `withEnv` step for more details o
 
 ## Build Parameters
 
-If you have configured your pipeline to accept parameters when it is built — **Build with Parameters** — they are accessible as Groovy variables of the same name.
+If you have configured your pipeline to accept parameters when it is built — **Build with Parameters** — they are accessible as Groovy variables inside `params`. Example:
+
+```groovy
+node {
+  sh "isFoo is ${params.isFoo}"
+  sh "isFoo is " + params.isFoo
+  if (params.isFoo) {
+    // do something
+  }
+```
 
 # Recording Test Results and Artifacts
 


### PR DESCRIPTION
I had an issue when working with Build parameters, https://github.com/jenkinsci/pipeline-plugin/blob/master/TUTORIAL.md#build-parameters is confusing. I
found the solution in [JENKINS-40235](https://issues.jenkins-ci.org/browse/JENKINS-40235) and added details here: http://stackoverflow.com/a/41276956/1092815