### PR TITLE
mark scoring-load-balancer job-level preferences as unsupported

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -149,7 +149,7 @@ Newly filed issues should bear the label `pipeline` for ease of tracking.
 - [X] `jobconfighistory`: supported as of 2.14
 - [X] `next-build-number`: supported as of 1.4
 - [ ] `tracking-svn` [JENKINS-38060](https://issues.jenkins-ci.org/browse/JENKINS-38060)
-- [ ] `BuildPreferenceJobProperty` (`scoring-load-balancer`): [JENKINS-41267](https://issues.jenkins-ci.org/browse/JENKINS-41267)
+- [ ] `scoring-load-balancer`: [JENKINS-41267](https://issues.jenkins-ci.org/browse/JENKINS-41267)
 
 ## Custom steps
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -149,6 +149,7 @@ Newly filed issues should bear the label `pipeline` for ease of tracking.
 - [X] `jobconfighistory`: supported as of 2.14
 - [X] `next-build-number`: supported as of 1.4
 - [ ] `tracking-svn` [JENKINS-38060](https://issues.jenkins-ci.org/browse/JENKINS-38060)
+- [ ] `BuildPreferenceJobProperty` (`scoring-load-balancer`): [JENKINS-41267](https://issues.jenkins-ci.org/browse/JENKINS-41267)
 
 ## Custom steps
 


### PR DESCRIPTION
I wasn't sure if this belongs in "Misc" or the "Build wrappers" section, and I also guessed a little bit on BuildPreferenceJobProperty; that's the class that was persisted in the config.xml of the job so it seemed right.