### PR TITLE
Update COMPATIBILITY.md to include R plug-in

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -167,6 +167,7 @@ For cases when a first-class Pipeline step (rather than an adaptation of functio
 - [X] `marathon`: `marathon` step since 1.2.1
 - [ ] `Release Plugin` (`release`): [JENKINS-40765](https://issues.jenkins-ci.org/browse/JENKINS-40765)
 - [ ] `M2 Release Plugin` (`m2release`): [JENKINS-40766](https://issues.jenkins-ci.org/browse/JENKINS-40766)
+- [X] `r`: (`r-plugin`): `r` step as of 0.4 via [pull request 4](https://github.com/jenkinsci/r-plugin/pull/4)
 
 # Plugin Developer Guide
 


### PR DESCRIPTION
[Previously submitted](https://github.com/jenkinsci/pipeline-plugin/pull/427/) in the incorrect category, but also from a branch in the jenkinsci org. Re-submitting from the fork under the suggested category.

Cheers
Bruno