### PR TITLE
Mention plot plugin Pipeline compatibility

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -81,6 +81,7 @@ Newly filed issues should bear the label `pipeline` for ease of tracking.
 - [X] `HockeyappRecorder` (`hockeyapp`): supported as of 1.2.2
 - [X] `WsCleanup` (`ws-cleanup`): supported as of 0.30
 - [X] `XCodeBuilder` (`xcode-plugin`): supported as of 2.0.0
+- [X] `PlotBuilder` (`plot`): supported as of 2.0.0
 
 ## Build wrappers
 


### PR DESCRIPTION
Support introduced in https://github.com/jenkinsci/plot-plugin/pull/32
`2.0.0` released and [plugin wiki](https://wiki.jenkins.io/display/JENKINS/Plot+Plugin) updated.