### PR TITLE
[JENKINS-32650] update Performance plugin and BlazeMeter plugin compatibility

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -62,7 +62,8 @@ Newly filed issues should bear the label `pipeline` for ease of tracking.
 - [X] `GitHubCommitNotifier`, `GitHubSetCommitStatusBuilder` (`github`): scheduled to be supported as of 1.14.3
 - [ ] `CoverityPublisher` (`coverity`): [JENKINS-32354](https://issues.jenkins-ci.org/browse/JENKINS-32354)
 - [X] `XUnitPublisher` and `XUnitBuilder` (`xunit`): scheduled to be supported as of 1.100
-- [ ] `PerformancePublisher` (`performance`): scheduled to be supported as of 3.1
+- [X] `PerformancePublisher` and `PerformanceTest` (`performance`): supported as of 3.1
+- [X] `BlazeMeterTest` (`blazemeter`): supported as of 4.0
 - [ ] `ZfjReporter` (`zephyr-for-jira-test-management`): [JENKINS-32801](https://issues.jenkins-ci.org/browse/JENKINS-32801)
 - [ ] `BapSshPublisher` (`publish-over-ssh`): [JENKINS-27963](https://issues.jenkins-ci.org/browse/JENKINS-27963)
 - [X] `PerfSigRecorder` and 5 more (`performance-signature-dynatrace`): supported as of 2.0


### PR DESCRIPTION
Hi, 
I want to update compatibility info in 2 plugins:
1) Performance plugin https://wiki.jenkins.io/display/JENKINS/Performance+Plugin
This plugin has build step: https://github.com/jenkinsci/performance-plugin/blob/master/src/main/java/hudson/plugins/performance/build/PerformanceTestBuild.java#L43
and post-build step (publisher): https://github.com/jenkinsci/performance-plugin/blob/master/src/main/java/hudson/plugins/performance/PerformancePublisher.java#L78
Pipeline supported since version 3.1 (released 2nd of June, 2017)

2) BlazeMeter plugin https://wiki.jenkins.io/display/JENKINS/blazemeter+Plugin
This plugin has build step: https://github.com/jenkinsci/blazemeter-plugin/blob/master/src/main/java/hudson/plugins/blazemeter/PerformanceBuilder.java#L47
Pipeline supported since version 4.0 (released 23.02.2018)